### PR TITLE
Fixed loading of compressed sig files & Python 2.7 support.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 import errno
 import hashlib
 import os
+import sys
+
 from functools import partial
 try:
     from urllib import urlretrieve
@@ -10,7 +12,11 @@ except ImportError:
     from urllib.request import urlretrieve
 
 from binaryninja import *
-from builtins import bytes
+try:
+    from builtins import bytes
+except ImportError:
+    from __builtin__ import bytes
+
 
 import nampa
 
@@ -119,7 +125,11 @@ def match_functions(bv, flirt_path, action, keep_manually_renamed, prefix):
         for funk in bv.functions:
             f_start = funk.start
             f_end = get_function_end(funk)
-            buff = bytes(bv.read(f_start, f_end - f_start + FUNCTION_TAIL_LENGTH))
+            buff = bv.read(f_start, f_end - f_start + FUNCTION_TAIL_LENGTH)
+            if sys.version_info[0] < 3:
+                buff = bytearray(buff)
+            else:
+                buff = bytes(buff)
             nampa.match_function(flirt, buff, f_start, callback)
 
         # ff = [f.start for f in bv.functions] + [bv.end]

--- a/nampa/crc.py
+++ b/nampa/crc.py
@@ -1,6 +1,10 @@
 from __future__ import print_function
 
-from builtins import range
+try:
+    from builtins import range
+except ImportError:
+    from __builtin__ import range
+
 
 POLY = 0x1021
 _crc_table = []

--- a/nampa/flirt.py
+++ b/nampa/flirt.py
@@ -515,7 +515,7 @@ def parse_flirt_file(f):
     if header.features & FlirtFeatureFlag.FEATURE_COMPRESSED:
         if header.version == 5:
             raise FlirtException('Compression in unsupported on flirt v5')
-        f = StringIO.StringIO(zlib.decompress(f.read()))  # Untested
+        f = StringIO(zlib.decompress(f.read()))
 
     tree = parse_tree(f, header.version, is_root=True)
 

--- a/nampa/flirt.py
+++ b/nampa/flirt.py
@@ -5,7 +5,13 @@
 from __future__ import print_function
 from . import binrw
 from . import crc
-from builtins import range, bytes, zip
+import sys
+
+try:
+    from builtins import range, bytes, zip
+except ImportError:
+    from __builtin__ import range, bytes, zip
+
 try:
     from typing import List
 except ImportError:
@@ -580,7 +586,10 @@ def match_function(sig, buff, addr, callback):
     # type: (FlirtFile, bytes) -> bool
     # assert type(buff) is bytes
     if type(buff) is str:
-        buff = bytes(buff)
+        if sys.version_info[0] < 3:
+            buff = bytearray(buff)
+        else:
+            buff = bytes(buff)
 
     for child in sig.root.children:
         if match_node(child, buff, addr, 0, callback):


### PR DESCRIPTION
I'm not too familiar with python, but this seems to correct an exception I was having when trying to load newer compressed sig files.