### PR TITLE
Use BytesIO to load compressed FLIRT files.

### DIFF
--- a/nampa/flirt.py
+++ b/nampa/flirt.py
@@ -11,10 +11,7 @@ try:
 except ImportError:
     pass
 from itertools import islice
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import BytesIO
 import zlib
 import logging
 
@@ -515,7 +512,7 @@ def parse_flirt_file(f):
     if header.features & FlirtFeatureFlag.FEATURE_COMPRESSED:
         if header.version == 5:
             raise FlirtException('Compression in unsupported on flirt v5')
-        f = StringIO(zlib.decompress(f.read()))
+        f = BytesIO(zlib.decompress(f.read()))
 
     tree = parse_tree(f, header.version, is_root=True)
 


### PR DESCRIPTION
Fixes this:

```
Traceback (most recent call last):
  File "C:\Program Files\Vector35\BinaryNinja\plugins\..\python\binaryninja\plugin.py", line 120, in _default_action
    action(view_obj)
  File "C:\Users\alex\AppData\Roaming\Binary Ninja\plugins\nampa\__init__.py", line 165, in match_functions_gui
    match_functions(bv, flirt_path, action, keep_manually_renamed, prefix)
  File "C:\Users\alex\AppData\Roaming\Binary Ninja\plugins\nampa\__init__.py", line 111, in match_functions
    flirt = nampa.parse_flirt_file(f)
  File "C:\Users\alex\AppData\Roaming\Binary Ninja\plugins\nampa\nampa\flirt.py", line 518, in parse_flirt_file
    f = StringIO(zlib.decompress(f.read()))
TypeError: initial_value must be str or None, not bytes
```