### PR TITLE
Add support for FLIRT v5 signature files

### DIFF
--- a/nampa/flirt.py
+++ b/nampa/flirt.py
@@ -510,9 +510,10 @@ def parse_flirt_file(f):
     header = parse_header(f)
     log.debug("Version: {}".format(header.version))
     if header.features & FlirtFeatureFlag.FEATURE_COMPRESSED:
-        if header.version == 5:
-            raise FlirtException('Compression in unsupported on flirt v5')
-        f = BytesIO(zlib.decompress(f.read()))
+        if header.version >= 5 and header.version < 7:
+            f = BytesIO(zlib.decompress(f.read(), -zlib.MAX_WBITS))
+        else:
+            f = BytesIO(zlib.decompress(f.read()))
 
     tree = parse_tree(f, header.version, is_root=True)
 


### PR DESCRIPTION
For v5 sigs, the `wbits` parameter in `zlib.decompress()` needs to be set to `-zlib.MAX_WBITS`.

This pull request reflects the change made to the radare2 repo in [this pull request](https://github.com/radareorg/radare2/pull/18958/commits/0b8f77f5ae85cef32e2cbe599253780c6b6012f4) onto nampa. 